### PR TITLE
[POC] Supporting Parquet and ORC formats on non-clusters by looking up

### DIFF
--- a/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/delegating/FileSystemResolver.java
+++ b/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/delegating/FileSystemResolver.java
@@ -1,0 +1,143 @@
+package org.pentaho.hadoop.shim.common.delegating;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.pentaho.di.connections.ConnectionDetails;
+import org.pentaho.di.connections.ConnectionManager;
+import org.pentaho.metastore.persist.MetaStoreAttribute;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+
+public class FileSystemResolver {
+
+  private static final ConnectionManager connMgr = ConnectionManager.getInstance();
+  /**
+   * Returns a Hadoop Filesystem.  If the original path is a named pentaho vfs reference
+   * (e.g. 'pvfs://HCP_connectionName/some/path'), this method will look up the
+   * details of the underlying vfs connection and return a FileSystem configured
+   * with the VFS connection info.
+   */
+  public static FileSystem get( URI uri, Configuration conf ) throws IOException, URISyntaxException {
+    Pair pair = resolveUriAndConf( uri, conf );
+    return FileSystem.get( pair.uri, pair.conf );
+  }
+
+  /**
+   * Returns the resolved path.  If the original path is a named pentaho vfs reference
+   * (e.g. 'pvfs://connectionName/some/path'), this method will look up the
+   * details of the underlying vfs connection and return a Path with the appropriate
+   * scheme and host.
+   */
+  public static Path realPath( String file ) throws URISyntaxException, IOException {
+    return new Path( resolveUriAndConf( new URI( file ), new Configuration() ).uri );
+  }
+
+  private static Pair resolveUriAndConf( URI uri, Configuration conf )
+    throws IOException, URISyntaxException {
+
+    Pair pair = Pair.of( uri, conf );
+    if ( uri.getScheme().toLowerCase().startsWith( "pvfs" ) ) {
+      ConnectionDetails details = connMgr.getConnectionDetails( uri.getHost() );
+
+      if ( details == null ) {
+        throw new IllegalStateException( format( "Could not find named VFS connection:  '%s'", uri.getHost() ) );
+      }
+      switch ( details.getType() ) {
+        case "hcp":
+          pair = hcpFileSystem( uri, conf, details );
+          break;
+        case "s3":
+          pair = s3FileSystem( uri, conf, details );
+          break;
+        default:
+          uri = new URI( details.getType(), uri.getHost(), uri.getPath(), "" );
+          pair = Pair.of( uri, conf );
+      }
+    }
+    return pair;
+  }
+
+  private static Pair s3FileSystem( URI uri, Configuration conf, ConnectionDetails details ) throws URISyntaxException {
+
+    // TODO - extract info from ConnectionDetails
+    AWSCredentials credentials = DefaultAWSCredentialsProviderChain.getInstance().getCredentials();
+    conf.set( "fs.s3a.access.key", credentials.getAWSAccessKeyId() );
+    conf.set( "fs.s3a.secret.key", credentials.getAWSSecretKey() );
+    if ( credentials instanceof BasicSessionCredentials ) {
+      conf.set( "fs.s3a.session.token", ( (BasicSessionCredentials) credentials ).getSessionToken() );
+    }
+    conf.set( "fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem" );
+    conf.set( "fs.s3.buffer.dir", System.getProperty( "java.io.tmpdir" ) );
+
+    uri = new URI( "s3a", uri.getHost(), uri.getPath(), null );
+    return Pair.of( uri, conf );
+  }
+
+  private static Pair hcpFileSystem( URI uri, Configuration conf, ConnectionDetails details )
+    throws IOException, URISyntaxException {
+    Map<String, String> props = getPropsFromConnectionDetails( details );
+    String namespace = props.get( "namespace" );
+    String port = props.get( "port" );
+
+    String username = props.get( "username" );
+    String proxyHost = props.get( "proxyHost" );
+    String proxyPort = props.get( "proxyPort" );
+
+    conf.set( "fs.s3a.access.key", Base64.getEncoder().encodeToString( username.getBytes() ) );
+    conf.set( "fs.s3a.secret.key", DigestUtils.md5Hex( props.get( "password" ) ) );
+    conf.set( "fs.s3a.endpoint", props.get( "tenant" ) + "." + props.get( "host" ) );
+    conf.set( "fs.s3a.signing-algorithm", "S3SignerType" );
+    conf.set( "fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem" );
+    conf.set( "fs.s3a.connection.ssl.enabled", "true" );
+    conf.set( "fs.s3a.attempts.maximum", "3" );
+    uri = new URI( "s3a", namespace, uri.getPath(), null );
+    return Pair.of( uri, conf );
+  }
+
+  private static Map<String, String> getPropsFromConnectionDetails( ConnectionDetails details ) {
+    // TODO consider modifiying ConnectionDetails to allow retrieval of props directly.
+    Class<? extends ConnectionDetails> clazz = details.getClass();
+    return Arrays.stream( clazz.getDeclaredFields() )
+      .filter( f -> f.isAnnotationPresent( MetaStoreAttribute.class ) )
+      .collect( Collectors.toMap( f -> f.getName(), getConnectionDetail( details ) ) );
+  }
+
+  private static Function<Field, String> getConnectionDetail( ConnectionDetails details ) {
+    return f -> {
+      try {
+        f.setAccessible( true );
+        Object val = f.get( details );
+        return val == null ? "" : val.toString();
+      } catch ( IllegalAccessException e ) {
+        throw new IllegalStateException( e );
+      }
+    };
+  }
+
+  private static class Pair {
+    URI uri;
+    Configuration conf;
+
+    private static Pair of( URI uri, Configuration conf ) {
+      Pair p = new Pair();
+      p.uri = uri;
+      p.conf = conf;
+      return p;
+    }
+  }
+}

--- a/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/format/orc/PentahoOrcOutputFormat.java
+++ b/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/format/orc/PentahoOrcOutputFormat.java
@@ -21,6 +21,7 @@
  ******************************************************************************/
 package org.pentaho.hadoop.shim.common.format.orc;
 
+import java.net.URI;
 import java.nio.file.FileAlreadyExistsException;
 
 import org.apache.hadoop.conf.Configuration;
@@ -33,8 +34,8 @@ import org.pentaho.hadoop.shim.api.format.IPentahoOrcOutputFormat;
 
 import org.apache.hadoop.mapreduce.Job;
 import org.pentaho.hadoop.shim.common.ConfigurationProxy;
+import org.pentaho.hadoop.shim.common.delegating.FileSystemResolver;
 import org.pentaho.hadoop.shim.common.format.HadoopFormatBase;
-import org.pentaho.hadoop.shim.common.format.S3NCredentialUtils;
 
 import java.util.List;
 
@@ -82,10 +83,14 @@ public class PentahoOrcOutputFormat extends HadoopFormatBase implements IPentaho
   }
 
   @Override public void setOutputFile( String file, boolean override ) throws Exception {
-    this.outputFilename = S3NCredentialUtils.scrubFilePathIfNecessary( file );
-    S3NCredentialUtils.applyS3CredentialsToHadoopConfigurationIfNecessary( file, job.getConfiguration() );
-    Path outputFile = new Path( outputFilename );
-    FileSystem fs = FileSystem.get( outputFile.toUri(), job.getConfiguration() );
+    //    this.outputFilename = S3NCredentialUtils.scrubFilePathIfNecessary( file );
+    //    S3NCredentialUtils.applyS3CredentialsToHadoopConfigurationIfNecessary( file, job.getConfiguration() );
+    //    Path outputFile = new Path( outputFilename );
+    //    FileSystem fs = FileSystem.get( outputFile.toUri(), job.getConfiguration() );
+    FileSystem fs = FileSystemResolver.get( new URI( file ), conf );
+    Path outputFile = FileSystemResolver.realPath( file );
+    this.outputFilename = outputFile.toString();
+
     if ( fs.exists( outputFile ) ) {
       if ( override ) {
         fs.delete( outputFile, true );

--- a/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/format/orc/PentahoOrcRecordReader.java
+++ b/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/format/orc/PentahoOrcRecordReader.java
@@ -37,9 +37,11 @@ import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.hadoop.shim.api.format.IOrcInputField;
 import org.pentaho.hadoop.shim.api.format.IOrcMetaData;
 import org.pentaho.hadoop.shim.api.format.IPentahoOrcInputFormat;
-import org.pentaho.hadoop.shim.common.format.S3NCredentialUtils;
+import org.pentaho.hadoop.shim.common.delegating.FileSystemResolver;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.NoSuchFileException;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -70,9 +72,13 @@ public class PentahoOrcRecordReader implements IPentahoOrcInputFormat.IPentahoRe
 
     Reader reader = null;
     try {
-      S3NCredentialUtils.applyS3CredentialsToHadoopConfigurationIfNecessary( fileName, conf );
-      filePath = new Path( S3NCredentialUtils.scrubFilePathIfNecessary( fileName ) );
-      fs = FileSystem.get( filePath.toUri(), conf );
+//      S3NCredentialUtils.applyS3CredentialsToHadoopConfigurationIfNecessary( fileName, conf );
+//      filePath = new Path( S3NCredentialUtils.scrubFilePathIfNecessary( fileName ) );
+//      fs = FileSystem.get( filePath.toUri(), conf );
+
+      fs = FileSystemResolver.get( new URI( fileName ), conf );
+      filePath = FileSystemResolver.realPath( fileName );
+
       if ( !fs.exists( filePath ) ) {
         throw new NoSuchFileException( fileName );
       }
@@ -94,7 +100,7 @@ public class PentahoOrcRecordReader implements IPentahoOrcInputFormat.IPentahoRe
 
       reader = OrcFile.createReader( filePath,
         OrcFile.readerOptions( conf ).filesystem( fs ) );
-    } catch ( IOException e ) {
+    } catch ( IOException | URISyntaxException e ) {
       throw new IllegalArgumentException( "Unable to read data from file " + fileName, e );
     }
     try {

--- a/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/format/parquet/delegate/DelegateFormatFactory.java
+++ b/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/format/parquet/delegate/DelegateFormatFactory.java
@@ -10,7 +10,7 @@ public class DelegateFormatFactory {
 
   public static Object getInputFormatInstance( NamedCluster namedCluster ) throws Exception {
 
-    String shimIdentifier = namedCluster.getShimIdentifier();
+    String shimIdentifier = getShimIdentifier( namedCluster );
     if ( ( shimIdentifier.startsWith( "cdh" ) && !shimIdentifier.startsWith( "cdh6" ) ) || (
       shimIdentifier.startsWith( "mapr" ) && !shimIdentifier.equals( "mapr60" ) ) ) {
       return new PentahoTwitterInputFormat( namedCluster );
@@ -19,9 +19,10 @@ public class DelegateFormatFactory {
     }
   }
 
+
   public static Object getOutputFormatInstance( NamedCluster namedCluster ) throws Exception {
 
-    String shimIdentifier = namedCluster.getShimIdentifier();
+    String shimIdentifier = getShimIdentifier( namedCluster );
     if ( ( shimIdentifier.startsWith( "cdh" ) && !shimIdentifier.startsWith( "cdh6" ) ) || (
       shimIdentifier.startsWith( "mapr" ) && !shimIdentifier.equals( "mapr60" ) ) ) {
       return new PentahoTwitterOutputFormat();
@@ -29,4 +30,13 @@ public class DelegateFormatFactory {
       return new PentahoApacheOutputFormat();
     }
   }
+
+  private static String getShimIdentifier( NamedCluster namedCluster ) {
+    if ( namedCluster == null ) {
+      return "UNKNOWN";
+    }
+    return namedCluster.getShimIdentifier();
+  }
+
+
 }

--- a/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/format/parquet/delegate/apache/PentahoApacheOutputFormat.java
+++ b/common-fragment-V1/src/main/java/org/pentaho/hadoop/shim/common/format/parquet/delegate/apache/PentahoApacheOutputFormat.java
@@ -22,6 +22,7 @@
 package org.pentaho.hadoop.shim.common.format.parquet.delegate.apache;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.FileAlreadyExistsException;
 import java.util.List;
 
@@ -41,8 +42,8 @@ import org.pentaho.di.core.RowMetaAndData;
 import org.pentaho.hadoop.shim.api.format.IParquetOutputField;
 import org.pentaho.hadoop.shim.api.format.IPentahoParquetOutputFormat;
 import org.pentaho.hadoop.shim.common.ConfigurationProxy;
+import org.pentaho.hadoop.shim.common.delegating.FileSystemResolver;
 import org.pentaho.hadoop.shim.common.format.HadoopFormatBase;
-import org.pentaho.hadoop.shim.common.format.S3NCredentialUtils;
 
 /**
  * Created by Vasilina_Terehova on 8/3/2017.
@@ -79,9 +80,11 @@ public class PentahoApacheOutputFormat extends HadoopFormatBase implements IPent
   @Override
   public void setOutputFile( String file, boolean override ) throws Exception {
     inClassloader( () -> {
-      S3NCredentialUtils.applyS3CredentialsToHadoopConfigurationIfNecessary( file, job.getConfiguration() );
-      outputFile = new Path( S3NCredentialUtils.scrubFilePathIfNecessary( file ) );
-      FileSystem fs = FileSystem.get( outputFile.toUri(), job.getConfiguration() );
+      //      S3NCredentialUtils.applyS3CredentialsToHadoopConfigurationIfNecessary( file, job.getConfiguration() );
+      //      outputFile = new Path( S3NCredentialUtils.scrubFilePathIfNecessary( file ) );
+
+      FileSystem fs = FileSystemResolver.get( new URI( file ), job.getConfiguration() );
+      outputFile = FileSystemResolver.realPath( file );
       if ( fs.exists( outputFile ) ) {
         if ( override ) {
           fs.delete( outputFile, true );

--- a/common-services-api/src/main/java/org/pentaho/big/data/api/cluster/service/locator/impl/NamedClusterServiceLocatorImpl.java
+++ b/common-services-api/src/main/java/org/pentaho/big/data/api/cluster/service/locator/impl/NamedClusterServiceLocatorImpl.java
@@ -128,7 +128,7 @@ public class NamedClusterServiceLocatorImpl implements NamedClusterServiceLocato
     try {
       readLock.lock();
       //The named Cluster is not fully defined.  We'll have to use the default shim
-      String shim = namedCluster.getShimIdentifier() != null ? namedCluster.getShimIdentifier() : getDefaultShim();
+      String shim = namedCluster != null && namedCluster.getShimIdentifier() != null ? namedCluster.getShimIdentifier() : getDefaultShim();
 
       Collection<ServiceFactoryAndRanking<?>> serviceFactoryAndRankings = null;
       if ( shim != null ) {

--- a/shims/apache/driver/pom.xml
+++ b/shims/apache/driver/pom.xml
@@ -1,0 +1,288 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.pentaho</groupId>
+    <artifactId>pentaho-hadoop-shims-apache-reactor</artifactId>
+    <version>9.0.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>pentaho-hadoop-shims-apache-driver</artifactId>
+  <version>9.0.0.0-SNAPSHOT</version>
+  <packaging>bundle</packaging>
+  <properties>
+    <vendor-driver.version>3.0.0.0.apache</vendor-driver.version>
+    <pentaho-code.version>11.0.0.0</pentaho-code.version>
+
+    <shim.name>apache</shim.name>
+    <!-- default folder -->
+    <automaton.version>1.11-8</automaton.version>
+    <org.apache.avro.version>1.8.0</org.apache.avro.version>
+    <hadoop-aws.version>3.1.0.3.0.0.0-1634</hadoop-aws.version>
+    <!-- client and default folders -->
+    <hadoop.version>3.1.0.3.0.0.0-1634</hadoop.version>
+    <!-- pmr folder -->
+    <protobuf-java.version>2.5.0</protobuf-java.version>
+    <commons-configuration.version>1.6</commons-configuration.version>
+    <commons-configuration2.version>2.1.1</commons-configuration2.version>
+    <geronimo-servlet_3.0_spec.version>1.0</geronimo-servlet_3.0_spec.version>
+    <org.apache.hadoop.version>3.1.0.3.0.0.0-1634</org.apache.hadoop.version>
+    <org.apache.orc.version>1.2.3</org.apache.orc.version>
+    <parquet.version>1.10.0.3.0.0.0-1634</parquet.version>
+    <org.antlr.version>3.5.2</org.antlr.version>
+    <joda-time.version>2.9.9</joda-time.version>
+
+    <shim-bundle-plugin.version>1.0</shim-bundle-plugin.version>
+    <org.apache.thrift.version>0.9.3</org.apache.thrift.version>
+
+    <!-- Guarantee the proper version for Jetty artifacts -->
+    <!-- Note the difference between \lib and \lib\client -->
+    <jetty.lib-folder.version>9.3.20.v20170531</jetty.lib-folder.version>
+    <jetty.client-folder.version>9.3.19.v20170502</jetty.client-folder.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- Guarantee the proper version for Jetty artifacts -->
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-annotations</artifactId>
+        <version>${jetty.lib-folder.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-client</artifactId>
+        <version>${jetty.lib-folder.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-jaas</artifactId>
+        <version>${jetty.lib-folder.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-jndi</artifactId>
+        <version>${jetty.lib-folder.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-plus</artifactId>
+        <version>${jetty.lib-folder.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-rewrite</artifactId>
+        <version>${jetty.lib-folder.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-runner</artifactId>
+        <version>${jetty.lib-folder.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-security</artifactId>
+        <version>${jetty.client-folder.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-servlet</artifactId>
+        <version>${jetty.client-folder.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-webapp</artifactId>
+        <version>${jetty.client-folder.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-xml</artifactId>
+        <version>${jetty.client-folder.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.pentaho</groupId>
+      <artifactId>pentaho-hadoop-shims-common-fragment-V1</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.pentaho</groupId>
+      <artifactId>shim-bundle-plugin</artifactId>
+      <version>${shim-bundle-plugin.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.pentaho</groupId>
+      <artifactId>shim-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-core</artifactId>
+      <version>${org.apache.hadoop.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <version>${org.apache.hadoop.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.orc</groupId>
+      <artifactId>orc-core</artifactId>
+      <version>${org.apache.orc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>${org.apache.avro.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro-mapred</artifactId>
+      <version>${org.apache.avro.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-hadoop-bundle</artifactId>
+      <version>${parquet.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+      <version>${org.apache.hadoop.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-core</artifactId>
+      <version>1.11.213</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+      <version>1.11.213</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-cbor</artifactId>
+      <version>2.9.10</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-aws</artifactId>
+      <version>${hadoop-aws.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <version>${joda-time.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!--- End dependencies for Pig -->
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>${org.apache.thrift.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-configuration</groupId>
+      <artifactId>commons-configuration</artifactId>
+      <version>${commons-configuration.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-configuration2</artifactId>
+      <version>${commons-configuration2.version}</version>
+    </dependency>
+
+
+  </dependencies>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>com.pentaho</groupId>
+        <artifactId>shim-bundle-plugin</artifactId>
+        <version>${shim-bundle-plugin.version}</version>
+        <configuration>
+          <resolverFilters>
+            <resolverFilter>
+              <include>
+                *:com.fasterxml.jackson.dataformat,*:com.amazonaws,*:hadoop-mapreduce-client-core,*:hadoop-common,*:orc-core,*:avro,
+                *:hadoop-aws,*:parquet-hadoop-bundle,*:hadoop-hdfs,
+                *:avro-mapred,
+                org.eclipse.jetty:*,
+                <!--Needed for Hive-->
+                *:commons-configuration,*:commons-configuration2
+              </include>
+              <exclude>
+                org.slf4j:*,
+                *:jersey*:jar:2.25.1,
+                *:*log4j*,*:xml-apis,*:xercesImpl,*:tests:*,
+                <!--Needed for hive-->
+                org.apache.hadoop:hadoop-yarn-registry
+              </exclude>
+              <transitive>true</transitive>
+            </resolverFilter>
+            <resolverFilter>
+              <include>
+                *:libthrift
+              </include>
+              <exclude>
+                *:tests:*
+              </exclude>
+              <transitive>false</transitive>
+            </resolverFilter>
+          </resolverFilters>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>resolve</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>${dependency.maven-bundle-plugin.version}</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>pentaho-hadoop-driver-V1</Bundle-SymbolicName>
+            <Bundle-Version>3.0.apache</Bundle-Version>
+            <Pentaho-Code-Version>${pentaho-code.version}</Pentaho-Code-Version>
+            <DynamicImport-Package>*</DynamicImport-Package>
+            <Import-Package>
+            </Import-Package>
+            <_exportcontents>
+            </_exportcontents>
+            <Embed-Dependency>*</Embed-Dependency>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/HadoopShim.java
+++ b/shims/apache/driver/src/main/java/org/pentaho/hadoop/shim/HadoopShim.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ *
+ * Pentaho Big Data
+ *
+ * Copyright (C) 2002-2019 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.hadoop.shim;
+
+
+
+import org.pentaho.hadoop.shim.common.ConfigurationProxyV2;
+import org.pentaho.hadoop.shim.common.HadoopShimImpl;
+
+public class HadoopShim extends HadoopShimImpl {
+
+  public HadoopShim() {
+    super();
+  }
+
+  @Override
+  public Class[] getHbaseDependencyClasses() {
+    return new Class[0];
+  }
+
+  @Override
+  public org.pentaho.hadoop.shim.api.internal.Configuration createConfiguration( String namedClusterConfigId ) {
+    ConfigurationProxyV2 conf = (ConfigurationProxyV2) super.createConfiguration( namedClusterConfigId );
+    conf.getJob().getConfiguration().setRestrictSystemProperties( false );
+    return conf;
+  }
+
+}

--- a/shims/apache/driver/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/shims/apache/driver/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="
+            http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <bean id="apacheShimIdentifier" class="org.pentaho.hadoop.shim.api.internal.ShimIdentifier" scope="singleton">
+        <argument value="apache"/>
+        <argument value="Apache"/>
+        <argument value="3.0"/>
+        <argument value="COMMUNITY"/>
+    </bean>
+
+    <service ref="apacheShimIdentifier" interface="org.pentaho.hadoop.shim.api.ShimIdentifierInterface"/>
+
+    <bean id="apacheHadoop" class="org.pentaho.hadoop.shim.HadoopShim" scope="singleton"/>
+
+    <service ref="apacheHadoop" interface="org.pentaho.hadoop.shim.spi.HadoopShim">
+        <service-properties>
+            <entry key="shim">
+                <value type="java.lang.String">apache</value>
+            </entry>
+        </service-properties>
+    </service>
+
+    <bean id="apacheFormatShim" class="org.pentaho.hadoop.shim.common.CommonFormatShim"/>
+
+    <service ref="apacheFormatShim" auto-export="interfaces">
+        <service-properties>
+            <entry key="shim">
+                <value type="java.lang.String">apache</value>
+            </entry>
+            <entry key="service">
+                <value type="java.lang.String">format</value>
+            </entry>
+        </service-properties>
+    </service>
+
+    <bean id="apacheFormatServiceFactory" class="org.pentaho.big.data.impl.shim.format.FormatServiceFactory">
+        <argument ref="apacheFormatShim"/>
+    </bean>
+
+    <service ref="apacheFormatServiceFactory"
+             interface="org.pentaho.hadoop.shim.api.cluster.NamedClusterServiceFactory">
+        <service-properties>
+            <entry key="shim">
+                <value type="java.lang.String">apache</value>
+            </entry>
+            <entry key="service">
+                <value type="java.lang.String">format</value>
+            </entry>
+        </service-properties>
+    </service>
+
+
+
+
+</blueprint>

--- a/shims/apache/kar/pom.xml
+++ b/shims/apache/kar/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>pentaho-hadoop-shims-apache-reactor</artifactId>
+    <groupId>org.pentaho</groupId>
+    <version>9.0.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>pentaho-hadoop-shims-apache-kar</artifactId>
+
+  <version>9.0.0.0-SNAPSHOT</version>
+  <packaging>kar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.pentaho</groupId>
+      <artifactId>pentaho-hadoop-shims-common-dependencies-V1</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.pentaho</groupId>
+      <artifactId>pentaho-hadoop-shims-common-fragment-V1</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.pentaho</groupId>
+      <artifactId>pentaho-hadoop-shims-apache-driver</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.karaf.tooling</groupId>
+        <artifactId>karaf-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <includeTransitiveDependency>false</includeTransitiveDependency>
+        </configuration>
+        <executions>
+          <execution>
+            <id>generate-features-file</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>features-generate-descriptor</goal>
+            </goals>
+            <configuration>
+              <outputFile>${project.build.directory}/classes/repository/features.xml</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/shims/apache/pom.xml
+++ b/shims/apache/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.pentaho</groupId>
+        <artifactId>pentaho-hadoop-shims-list</artifactId>
+        <version>9.0.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>pentaho-hadoop-shims-apache-reactor</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>driver</module>
+        <module>kar</module>
+    </modules>
+</project>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -271,6 +271,7 @@
         <module>hdp26</module>
         <module>hdp30</module>
         <module>emr521</module>
+        <module>apache</module>
       </modules>
     </profile>
 
@@ -331,6 +332,18 @@
       </activation>
       <modules>
         <module>emr521</module>
+      </modules>
+    </profile>
+
+    <profile>
+      <id>apache</id>
+      <activation>
+        <property>
+          <name>!skipDefault</name>
+        </property>
+      </activation>
+      <modules>
+        <module>apache</module>
       </modules>
     </profile>
 


### PR DESCRIPTION
connection details stored in named vfs connections.  The POC
handles "s3" and "hcp".  Could be extended to Google Cloud Storage.

This POC also has a slimmed down "apache" shim that can be used
when no named cluster is available, e.g. writing to S3, HCP, Local
Filesystem.